### PR TITLE
Hi Luke

### DIFF
--- a/lib/clickatell/api/error.rb
+++ b/lib/clickatell/api/error.rb
@@ -3,10 +3,10 @@ module Clickatell
   
     # Clickatell API Error exception.
     class Error < StandardError
-      attr_reader :code, :message, :response
+      attr_reader :code, :message
       
-      def initialize(code, message, response)
-        @code, @message, @response = code, message, response
+      def initialize(code, message)
+        @code, @message = code, message
       end
       
       # Creates a new Error from a Clickatell HTTP response string
@@ -14,14 +14,12 @@ module Clickatell
       #
       #  Error.parse("ERR: 001, Authentication error")
       #  # =>  #<Clickatell::API::Error code='001' message='Authentication error'>
-      def self.parse(response)
-        response.body.split("\n").map do |line|
-          if line =~ /^ERR: (\d+), (.*)$/
-            code, message = $1.to_i, $2
-            break
-          end
+      def self.parse(error_string)
+        if error_string =~ /^ERR: (\d+), (.*)$/
+          self.new($1, $2)
+        else
+          self.new(nil, error_string)
         end
-        self.new(code, message, response)
       end
     end
   

--- a/lib/clickatell/api/error.rb
+++ b/lib/clickatell/api/error.rb
@@ -3,10 +3,10 @@ module Clickatell
   
     # Clickatell API Error exception.
     class Error < StandardError
-      attr_reader :code, :message
+      attr_reader :code, :message, :response
       
-      def initialize(code, message)
-        @code, @message = code, message
+      def initialize(code, message, response)
+        @code, @message, @response = code, message, response
       end
       
       # Creates a new Error from a Clickatell HTTP response string
@@ -14,10 +14,14 @@ module Clickatell
       #
       #  Error.parse("ERR: 001, Authentication error")
       #  # =>  #<Clickatell::API::Error code='001' message='Authentication error'>
-      def self.parse(error_string)
-        error_details = error_string.split(':').last.strip
-        code, message = error_details.split(',').map { |s| s.strip }
-        self.new(code, message)
+      def self.parse(response)
+        response.body.split("\n").map do |line|
+          if line =~ /^ERR: (\d+), (.*)$/
+            code, message = $1.to_i, $2
+            break
+          end
+        end
+        self.new(code, message, response)
       end
     end
   

--- a/lib/clickatell/response.rb
+++ b/lib/clickatell/response.rb
@@ -12,10 +12,12 @@ module Clickatell
       def parse(http_response)
         return { 'OK' => 'session_id' } if API.test_mode
         
-        if http_response.body.scan(/ERR/).any?
-          raise Clickatell::API::Error.parse(http_response.body)
+        lines = http_response.body.split("\n").reject {|line| line.strip.size == 0 }
+        
+        if lines.size == 1 && lines.first =~ /^ERR:/ && 
+          raise Clickatell::API::Error.parse(lines.first)
         end
-        results = http_response.body.split("\n").map do |line|
+        results = lines.map do |line|
           # YAML.load converts integer strings that have leading zeroes into integers
           # using octal rather than decimal.  This isn't what we want, so we'll strip out any
           # leading zeroes in numbers here.

--- a/lib/clickatell/response.rb
+++ b/lib/clickatell/response.rb
@@ -14,7 +14,7 @@ module Clickatell
         
         lines = http_response.body.split("\n").reject {|line| line.strip.size == 0 }
         
-        if lines.size == 1 && lines.first =~ /^ERR:/ && 
+        if lines.size == 1 && lines.first =~ /^ERR:/
           raise Clickatell::API::Error.parse(lines.first)
         end
         results = lines.map do |line|


### PR DESCRIPTION
I've changed the way error handling works so if you send multiple messages at once, we won't raise an exception just because one of those messages failed. You'd really want to be able to parse the response and deal with them indidivually.

Plus, when the error message ends with a colon, the error parsing returned empty code and messages.

Here's the error I was getting back:

ERR: 105, Invalid Destination Address To: 
ERR: 105, Invalid Destination Address To: 
ERR: 105, Invalid Destination Address To: 

(many more like these)

//Lars
