### PR TITLE
Added :concat key to allowed options

### DIFF
--- a/lib/clickatell/api.rb
+++ b/lib/clickatell/api.rb
@@ -73,9 +73,10 @@ module Clickatell
     #    :from - the from number/name
     #    :set_mobile_originated - mobile originated flag
     #    :client_message_id - user specified message id that can be used in place of Clickatell issued API message ID for querying message
+    #    :concat - number of concatenations allowed. I.E. how long is a message allowed to be.
     # Returns a new message ID if successful.
     def send_message(recipient, message_text, opts={})
-      valid_options = opts.only(:from, :mo, :callback, :climsgid)
+      valid_options = opts.only(:from, :mo, :callback, :climsgid, :concat)
       valid_options.merge!(:req_feat => '48') if valid_options[:from]
       valid_options.merge!(:mo => '1') if opts[:set_mobile_originated]
       valid_options.merge!(:climsgid => opts[:client_message_id]) if opts[:client_message_id]

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -154,6 +154,12 @@ module Clickatell
       @api.send_message('4477791234567', 'hello world', :client_message_id => 12345678)
     end
     
+    it "should set the concat flag to the number passed in the options hash" do
+      @executor.expects(:execute).with('sendmsg', 'http', has_entry(:concat => 3)).returns(response=mock('response'))
+      Response.stubs(:parse).with(response).returns('ID' => 'message_id')
+      @api.send_message('4477791234567', 'hello world', :concat => 3)
+    end
+    
     it "should ignore any invalid parameters when sending a message" do
       @executor.expects(:execute).with('sendmsg', 'http', Not(has_key(:any_old_param))).returns(response = stub('response'))
       Response.stubs(:parse).returns('ID' => 'foo')


### PR DESCRIPTION
I read that you don't claim to support the entire api but I hope this can make it into a future version.

The concat parameter is a numeric flag telling the api to allow longer messages (sending multiple concatenated messages to the phone).

I rote the spec blind. I am on ruby 1.9.2 and rspec 2.0 and something (did not figure out what) does not work ok. I hope it passes, though.
